### PR TITLE
#1 モバイルのレイアウト修正

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,17 +19,17 @@
           <h2 class="subtitle" >絞り込み</h2>
           <p class="block">
             <template v-for="year in years">
-              <label class="checkbox">
+              <label class="checkbox" style="margin-right:2em">
                 <input type="checkbox" name="years" :value="year" v-model="selectedYears"> {{year}}年生
-              </label>&nbsp;&nbsp;
+              </label>
             </template>
           </p>
           
           <p class="block">
             <template v-for="subj in subjs">
-              <label class="checkbox">
+              <label class="checkbox" style="margin-right:2em">
                 <input type="checkbox" name="subjs" :value="subj" v-model="selectedSubjs"> {{subj}}
-              </label>&nbsp;&nbsp;
+              </label>
             </template>
           </p>
         </div>


### PR DESCRIPTION
fix:HTMLの&nbsp;&nbsp;を style="margin-right:2em"へ
#1 のissueの通りレイアウトを修正しました。
それに加え文法的な間違いはないけれどスタイルはちゃんとCSSで実装した方が綺麗かなと思いました


PS
京都産業大学の情報理工で大学生をやっているものです
青学のabe先生のTwitterで見つけました。大学生同士プログラミング教育盛り上げていきましょう。応援してます。

